### PR TITLE
fix: hidden input displaying label

### DIFF
--- a/formfor.go
+++ b/formfor.go
@@ -310,6 +310,11 @@ func (f formFor) CheckboxTag(field string, opts tags.Options) *tags.Tag {
 // InputTag creates an input for a field on the form Struct
 func (f formFor) InputTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
+
+	if opts["type"] == "hidden" {
+		return f.form.HiddenTag(opts)
+	}
+
 	f.addFormatTag(field, opts)
 
 	return divWrapper(opts, func(opts tags.Options) tags.Body {

--- a/formfor_test.go
+++ b/formfor_test.go
@@ -18,8 +18,6 @@ func TestFormForInputTag(t *testing.T) {
 			"type": "hidden",
 		})
 
-		fmt.Println(string(it.HTML()))
-
 		if strings.Contains(string(it.HTML()), `<label class="block text-sm font-medium text-gray-700 mb-1">Name</label>`) {
 			t.Fatalf("form shouldn't contain label")
 		}

--- a/formfor_test.go
+++ b/formfor_test.go
@@ -1,0 +1,31 @@
+package tailush_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/tags/v3"
+	"github.com/wawandco/tailush"
+)
+
+func TestFormForInputTag(t *testing.T) {
+	t.Run("type hidden", func(t *testing.T) {
+		var model struct{}
+		f := tailush.NewFormFor(model, tags.Options{}, newHctx())
+
+		it := f.InputTag("", tags.Options{
+			"type": "hidden",
+		})
+
+		fmt.Println(string(it.HTML()))
+
+		if strings.Contains(string(it.HTML()), `<label class="block text-sm font-medium text-gray-700 mb-1">Name</label>`) {
+			t.Fatalf("form shouldn't contain label")
+		}
+
+		if !strings.Contains(string(it.HTML()), `<input id="-" name="" tags-field="" type="hidden" value="" />`) {
+			t.Fatalf("form should contain hidden input")
+		}
+	})
+}


### PR DESCRIPTION
Implement fix to avoid label display in **FormFor** when using `<%= f.InputTag("Something", {type: "hidden"}) %>`

fixes: #2 